### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jorgedemetrio/tpl_generico_joomla/security/code-scanning/2](https://github.com/jorgedemetrio/tpl_generico_joomla/security/code-scanning/2)

To fix this issue, add a `permissions` key to restrict the `GITHUB_TOKEN` used in the workflow to the least privilege necessary. Since the job only appears to check out source code and invoke a scan action (no repository-modifying steps), the minimal required permission should be `contents: read`. This can be added at the workflow root (applies to all jobs in the workflow) or under the `sonarqube` job itself (just for this job). As there is only one job in this workflow and no indication of varying permission needs among different jobs, it's best to add it at the workflow root, right after the `name` field and before `on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
