### PR TITLE
Centralize CSS variable generation and escape menu URLs

### DIFF
--- a/tpl_generico/helper.php
+++ b/tpl_generico/helper.php
@@ -1,0 +1,50 @@
+<?php
+use Joomla\CMS\Registry\Registry;
+
+defined('_JEXEC') or die;
+
+/**
+ * Helper methods for tpl_generico template.
+ */
+class TplGenericoHelper
+{
+    /**
+     * Build CSS variables string from template parameters.
+     *
+     * @param  Registry  $params  Template parameters
+     * @return string             CSS variables ready for inline use
+     */
+    public static function buildCssVars(Registry $params): string
+    {
+        $cssVars  = "--cor-primaria: {$params->get('primaryColor', '#1F4E79')};";
+        $cssVars .= "--cor-secundaria: {$params->get('secondaryColor', '#2E7D32')};";
+        $cssVars .= "--cor-cta: {$params->get('ctaColor', '#2F80ED')};";
+        $cssVars .= "--cor-texto: {$params->get('textColor', '#222222')};";
+        $cssVars .= "--cor-texto-secundario: {$params->get('textSecondaryColor', '#6B7280')};";
+        $cssVars .= "--cor-superficie-clara: {$params->get('surfaceLightColor', '#FFFFFF')};";
+        $cssVars .= "--cor-superficie-clara-topo: {$params->get('surfaceLightColorTopo', '#FFFFFF')};";
+        $cssVars .= "--cor-superficie-alt: {$params->get('surfaceAltColor', '#F5F7FA')};";
+        $cssVars .= "--cor-borda: {$params->get('borderColor', '#E5E7EB')};";
+        $cssVars .= "--espaco-interno-card: {$params->get('espacoInternoCard', '1.5rem')};";
+        $cssVars .= "--margin-topo-card: {$params->get('margemTopoCard', '10px')};";
+        $cssVars .= "--espaco-interno-titulo-card: {$params->get('espacoInternoTituloCard', '1.5rem')};";
+        $cssVars .= "--margin-topo-titulo-card: {$params->get('margemTopoTituloCard', '10px')};";
+        $cssVars .= "--cor-footer: {$params->get('footerColor', '#0F172A')};";
+        $cssVars .= "--familia-fonte-primaria: {$params->get('fontFamilyPrimary', 'system-ui, sans-serif')};";
+        $cssVars .= "--tamanho-base-fonte: {$params->get('fontSizeBase', '1rem')};";
+        $cssVars .= "--peso-fonte-normal: {$params->get('fontWeightNormal', '400')};";
+        $cssVars .= "--peso-fonte-titulos: {$params->get('fontWeightHeadings', '700')};";
+        $cssVars .= "--raio-borda-global: {$params->get('borderRadius', '4')}px;";
+
+        $spacing = $params->get('verticalSpacing', 'M');
+        $spacingValue = '2rem';
+        if ($spacing === 'S') {
+            $spacingValue = '1rem';
+        } elseif ($spacing === 'L') {
+            $spacingValue = '3rem';
+        }
+        $cssVars .= "--espacamento-vertical-global: {$spacingValue};";
+
+        return $cssVars;
+    }
+}

--- a/tpl_generico/html/mod_menu/default.php
+++ b/tpl_generico/html/mod_menu/default.php
@@ -44,7 +44,7 @@ if (!function_exists('renderMenuItems')) {
                 $linkAttrs[] = 'data-bs-toggle="dropdown"';
                 $linkAttrs[] = 'aria-expanded="false"';
             } else {
-                $linkAttrs[] = 'href="' . $item->flink . '"';
+                $linkAttrs[] = 'href="' . htmlspecialchars($item->flink, ENT_QUOTES, 'UTF-8') . '"';
             }
             if ($item->browserNav == 1) {
                 $linkAttrs[] = 'target="_blank"';

--- a/tpl_generico/index.php
+++ b/tpl_generico/index.php
@@ -7,6 +7,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Helper\ModuleHelper;
+require_once __DIR__ . '/helper.php';
 
 /** @var Joomla\CMS\Document\HtmlDocument $this */
 $app   = Factory::getApplication();
@@ -25,31 +26,7 @@ if ($faviconApple = $this->params->get('faviconApple')) {
 }
 
 // CSS Variable Generation
-$cssVars = '';
-$cssVars .= "--cor-primaria: {$this->params->get('primaryColor', '#1F4E79')};";
-$cssVars .= "--cor-secundaria: {$this->params->get('secondaryColor', '#2E7D32')};";
-$cssVars .= "--cor-cta: {$this->params->get('ctaColor', '#2F80ED')};";
-$cssVars .= "--cor-texto: {$this->params->get('textColor', '#222222')};";
-$cssVars .= "--cor-texto-secundario: {$this->params->get('textSecondaryColor', '#6B7280')};";
-$cssVars .= "--cor-superficie-clara: {$this->params->get('surfaceLightColor', '#FFFFFF')};";
-$cssVars .= "--cor-superficie-clara-topo: {$this->params->get('surfaceLightColorTopo', '#FFFFFF')};";
-$cssVars .= "--espaco-interno-card: {$this->params->get('espacoInternoCard', '1.5rem')};";
-$cssVars .= "--margin-topo-card: {$this->params->get('margemTopoCard', '10px')};";
-$cssVars .= "--espaco-interno-titulo-card: {$this->params->get('espacoInternoTituloCard', '1.5rem')};";
-$cssVars .= "--margin-topo-titulo-card: {$this->params->get('margemTopoTituloCard', '10px')};";
-$cssVars .= "--cor-superficie-alt: {$this->params->get('surfaceAltColor', '#F5F7FA')};";
-$cssVars .= "--cor-borda: {$this->params->get('borderColor', '#E5E7EB')};";
-$cssVars .= "--cor-footer: {$this->params->get('footerColor', '#0F172A')};";
-$cssVars .= "--familia-fonte-primaria: {$this->params->get('fontFamilyPrimary', 'system-ui, sans-serif')};";
-$cssVars .= "--tamanho-base-fonte: {$this->params->get('fontSizeBase', '1rem')};";
-$cssVars .= "--peso-fonte-normal: {$this->params->get('fontWeightNormal', '400')};";
-$cssVars .= "--peso-fonte-titulos: {$this->params->get('fontWeightHeadings', '700')};";
-$cssVars .= "--raio-borda-global: {$this->params->get('borderRadius', '4')}px;";
-$spacing = $this->params->get('verticalSpacing', 'M');
-$spacingValue = '2rem';
-if ($spacing === 'S') $spacingValue = '1rem';
-if ($spacing === 'L') $spacingValue = '3rem';
-$cssVars .= "--espacamento-vertical-global: {$spacingValue};";
+$cssVars = TplGenericoHelper::buildCssVars($this->params);
 
 // Enable assets
 HTMLHelper::_('bootstrap.framework');

--- a/tpl_generico/offline.php
+++ b/tpl_generico/offline.php
@@ -7,6 +7,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Helper\ModuleHelper;
+require_once __DIR__ . '/helper.php';
 
 /** @var Joomla\CMS\Document\HtmlDocument $this */
 
@@ -19,31 +20,7 @@ HTMLHelper::_('bootstrap.framework');
 $params = $app->getTemplate(true)->params;
 
 // CSS Variable Generation
-$cssVars = '';
-$cssVars .= "--cor-primaria: {$params->get('primaryColor', '#1F4E79')};";
-$cssVars .= "--cor-secundaria: {$params->get('secondaryColor', '#2E7D32')};";
-$cssVars .= "--cor-cta: {$params->get('ctaColor', '#2F80ED')};";
-$cssVars .= "--cor-texto: {$params->get('textColor', '#222222')};";
-$cssVars .= "--cor-texto-secundario: {$params->get('textSecondaryColor', '#6B7280')};";
-$cssVars .= "--cor-superficie-clara: {$params->get('surfaceLightColor', '#FFFFFF')};";
-$cssVars .= "--cor-superficie-clara-topo: {$params->get('surfaceLightColorTopo', '#FFFFFF')};";
-$cssVars .= "--cor-superficie-alt: {$params->get('surfaceAltColor', '#F5F7FA')};";
-$cssVars .= "--cor-borda: {$params->get('borderColor', '#E5E7EB')};";
-$cssVars .= "--espaco-interno-card: {$params->get('espacoInternoCard', '1.5rem')};";
-$cssVars .= "--margin-topo-card: {$params->get('margemTopoCard', '10px')};";
-$cssVars .= "--espaco-interno-titulo-card: {$params->get('espacoInternoTituloCard', '1.5rem')};";
-$cssVars .= "--margin-topo-titulo-card: {$params->get('margemTopoTituloCard', '10px')};";
-$cssVars .= "--cor-footer: {$params->get('footerColor', '#0F172A')};";
-$cssVars .= "--familia-fonte-primaria: {$params->get('fontFamilyPrimary', 'system-ui, sans-serif')};";
-$cssVars .= "--tamanho-base-fonte: {$params->get('fontSizeBase', '1rem')};";
-$cssVars .= "--peso-fonte-normal: {$params->get('fontWeightNormal', '400')};";
-$cssVars .= "--peso-fonte-titulos: {$params->get('fontWeightHeadings', '700')};";
-$cssVars .= "--raio-borda-global: {$params->get('borderRadius', '4')}px;";
-$spacing = $params->get('verticalSpacing', 'M');
-$spacingValue = '2rem';
-if ($spacing === 'S') $spacingValue = '1rem';
-if ($spacing === 'L') $spacingValue = '3rem';
-$cssVars .= "--espacamento-vertical-global: {$spacingValue};";
+$cssVars = TplGenericoHelper::buildCssVars($params);
 
 // Enable assets
 $wa->usePreset('tpl_generico.preset')->addInlineStyle(":root { $cssVars }");


### PR DESCRIPTION
## Summary
- Centralize CSS variable generation in new `TplGenericoHelper`
- Sanitize menu links by escaping URLs in menu override

## Testing
- `php -l tpl_generico/helper.php tpl_generico/index.php tpl_generico/offline.php tpl_generico/html/mod_menu/default.php`


------
https://chatgpt.com/codex/tasks/task_e_68acab6c39988333a1b8d9c2cf81006c