### PR TITLE
fix(mod_menu): alinhar menu principal à esquerda no navbar

### DIFF
--- a/tpl_generico/html/mod_menu/default.php
+++ b/tpl_generico/html/mod_menu/default.php
@@ -65,6 +65,6 @@ if (!function_exists('renderMenuItems')) {
 
 $id = $params->get('tag_id', 'main-menu-' . $module->id);
 ?>
-<ul class="navbar-nav ms-auto" id="<?php echo $id; ?>">
+<ul class="navbar-nav me-auto" id="<?php echo $id; ?>">
     <?php renderMenuItems($list); ?>
 </ul>


### PR DESCRIPTION
Troca a classe ms-auto (margin-left: auto, empurra ul para a direita) por me-auto (margin-right: auto, empurra ul para a esquerda) no override default.php do mod_menu, deixando o menu logo após o logo/brand em vez de colado à direita do navbar.