### PR TITLE
fix(tpl_generico): cores do admin agora sao aplicadas em todo o site

### DIFF
--- a/tpl_generico/error.php
+++ b/tpl_generico/error.php
@@ -6,6 +6,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
+require_once __DIR__ . '/helper.php';
+
 /** @var Joomla\CMS\Document\ErrorDocument $this */
 
 $app = Factory::getApplication();
@@ -21,9 +23,13 @@ try {
 	$logoFile = $params->get('logoFile');
 	$siteTitle = $params->get('siteTitle');
 } catch (\Exception $e) {
+	$params = null;
 	$logoFile = '';
 	$siteTitle = '';
 }
+
+// Aplica as cores do admin tambem na pagina de erro.
+$this->addStyleDeclaration(':root { ' . TplGenericoHelper::buildCssVars($params) . ' }');
 
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 // Tamanho fixo do logo na pagina de erro (independe do parametro do template).

--- a/tpl_generico/helper.php
+++ b/tpl_generico/helper.php
@@ -67,7 +67,50 @@ if (!class_exists('TplGenericoHelper', false)) {
             }
             $cssVars .= "--espacamento-vertical-global: {$spacingValue};";
 
+            // Sincroniza as variaveis do Bootstrap 5 com as cores do template,
+            // garantindo que componentes do core (alerts, badges, navs, links,
+            // dropdowns, paginacao, etc.) respeitem as cores definidas no admin.
+            $primaryRgb   = self::hexToRgb($get('primaryColor', '#1F4E79'));
+            $secondaryRgb = self::hexToRgb($get('secondaryColor', '#2E7D32'));
+            $ctaRgb       = self::hexToRgb($get('ctaColor', '#2F80ED'));
+
+            $cssVars .= '--bs-primary: var(--cor-primaria);';
+            $cssVars .= '--bs-secondary: var(--cor-secundaria);';
+            $cssVars .= "--bs-primary-rgb: {$primaryRgb};";
+            $cssVars .= "--bs-secondary-rgb: {$secondaryRgb};";
+            $cssVars .= '--bs-link-color: var(--cor-cta);';
+            $cssVars .= "--bs-link-color-rgb: {$ctaRgb};";
+            $cssVars .= '--bs-link-hover-color: var(--cor-primaria);';
+            $cssVars .= "--bs-link-hover-color-rgb: {$primaryRgb};";
+            $cssVars .= '--bs-body-color: var(--cor-texto);';
+            $cssVars .= '--bs-body-bg: var(--cor-superficie-clara);';
+            $cssVars .= '--bs-border-color: var(--cor-borda);';
+            $cssVars .= '--bs-border-radius: var(--raio-borda-global);';
+            $cssVars .= '--bs-font-sans-serif: var(--familia-fonte-primaria);';
+            $cssVars .= '--bs-body-font-family: var(--familia-fonte-primaria);';
+            $cssVars .= '--bs-body-font-size: var(--tamanho-base-fonte);';
+            $cssVars .= '--bs-body-font-weight: var(--peso-fonte-normal);';
+
             return $cssVars;
+        }
+
+        /**
+         * Converte um valor hexadecimal (#RGB ou #RRGGBB) na tripla "R, G, B"
+         * usada pelas variaveis `--bs-*-rgb` do Bootstrap 5.
+         */
+        private static function hexToRgb($hex): string
+        {
+            $hex = is_string($hex) ? trim($hex) : '';
+            $hex = ltrim($hex, '#');
+
+            if (strlen($hex) === 3) {
+                $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+            }
+            if (!preg_match('/^[0-9a-fA-F]{6}$/', $hex)) {
+                return '0, 0, 0';
+            }
+
+            return hexdec(substr($hex, 0, 2)) . ', ' . hexdec(substr($hex, 2, 2)) . ', ' . hexdec(substr($hex, 4, 2));
         }
 
         /**

--- a/tpl_generico/index.php
+++ b/tpl_generico/index.php
@@ -30,7 +30,11 @@ $cssVars = TplGenericoHelper::buildCssVars($this->params);
 
 // Enable assets
 HTMLHelper::_('bootstrap.framework');
-$wa->usePreset('tpl_generico.preset')->addInlineStyle(":root { $cssVars }");
+$wa->usePreset('tpl_generico.preset');
+// addStyleDeclaration entra no buffer de inline styles do documento, garantindo
+// que estas variaveis sejam renderizadas DEPOIS de bootstrap.css/template.css,
+// vencendo qualquer :root anterior e fazendo as cores do admin de fato valerem.
+$this->addStyleDeclaration(":root { $cssVars }");
 
 
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');

--- a/tpl_generico/offline.php
+++ b/tpl_generico/offline.php
@@ -23,8 +23,10 @@ $params = $app->getTemplate(true)->params;
 $cssVars = TplGenericoHelper::buildCssVars($params);
 
 // Enable assets
-$wa->usePreset('tpl_generico.preset')->addInlineStyle(":root { $cssVars }");
+$wa->usePreset('tpl_generico.preset');
 $wa->useStyle('tpl_generico.offline');
+// Inline depois dos <link>s garante que as cores do admin sobrescrevam o CSS base.
+$this->addStyleDeclaration(":root { $cssVars }");
 
 
 // Logo file or site title param


### PR DESCRIPTION
Causa raiz: o template definia --cor-* via :root inline, mas o Bootstrap 5 usa --bs-primary/--bs-secondary/--bs-link-color/--bs-body-*/--bs-border-* nos componentes do core (alerts, badges, navs, dropdowns, paginacao, formularios, etc.). Como essas variaveis do Bootstrap nao eram sobrescritas, os componentes seguiam azul/cinza padrao mesmo apos o admin escolher outras cores.

Mudancas:

- helper.php: buildCssVars agora mapeia todas as --cor-* para as --bs-* equivalentes e calcula tambem --bs-*-rgb (necessario para rgba() em hovers/focus do Bootstrap). Inclui hexToRgb privado seguro contra valores invalidos.

- index.php/offline.php/error.php: troca de \->...->addInlineStyle por \->addStyleDeclaration. addStyleDeclaration entra no buffer de inline styles renderizado APOS os <link>s, garantindo precedencia sobre bootstrap.css/template.css.

- error.php: passa a aplicar tambem as variaveis CSS e a carregar helper.php (antes o documento de erro nao seguia as cores do admin).