### PR TITLE
fix(tpl_generico): viewport responsiva + container full-width no mobile

### DIFF
--- a/tpl_generico/index.php
+++ b/tpl_generico/index.php
@@ -14,6 +14,12 @@ $app   = Factory::getApplication();
 $input = $app->getInput();
 $wa    = $this->getWebAssetManager();
 
+// Viewport responsivo: sem isto o celular renderiza a pagina como desktop (~980px),
+// o Bootstrap aplica .container { max-width: 720px } e o navegador "da zoom out" na
+// pagina inteira — o container fica muito mais estreito que a tela do celular.
+// (error.php/offline.php/component.php ja definem; o index.php estava sem.)
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1');
+
 // Favicon
 if ($faviconIco = $this->params->get('faviconIco')) {
     $this->addHeadLink(Uri::root(true) . '/' . htmlspecialchars($faviconIco), 'icon', 'rel', ['type' => 'image/vnd.microsoft.icon']);

--- a/tpl_generico/media/css/template.css
+++ b/tpl_generico/media/css/template.css
@@ -30,7 +30,16 @@ body.site {
     flex-grow: 1;
 }
 
-/* Container "boxed" com largura maxima configuravel no admin. */
+/* No mobile/tablet o .container ocupa 100% da largura da tela. Neutraliza os
+   passos intermediarios do Bootstrap (.container vira 540/720/960px a partir de
+   576/768/992px), que deixavam margens laterais grandes em celulares maiores. */
+@media (max-width: 1199.98px) {
+    .container {
+        max-width: 100%;
+    }
+}
+
+/* Container "boxed" com largura maxima configuravel no admin — so no desktop. */
 @media (min-width: 1200px) {
     .container {
         max-width: var(--generico-container-max-width, 1140px);


### PR DESCRIPTION
- index.php nao declarava meta viewport (so component/error/offline tinham). Sem ela o celular renderiza a pagina como desktop (~980px), o Bootstrap aplica .container { max-width: 720px } e o navegador "da zoom out" na pagina inteira, deixando o container muito mais estreito que a tela. Adiciona width=device-width, initial-scale=1.
- template.css: abaixo de 1200px o .container passa a 100% da largura, neutralizando os passos 540/720/960px do Bootstrap que criavam margens laterais grandes em celulares/tablets. O modo "boxed" (largura maxima configuravel no admin) continua valendo so no desktop (>=1200px).